### PR TITLE
Allow Environment variable to override SEGMENT_DURATION

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ class HLSVod {
     this.segments = {};
     this.audioSegments = {};
     this.mediaSequences = [];
-    this.SEQUENCE_DURATION = 60;
+    this.SEQUENCE_DURATION = process.env.SEQUENCE_DURATION ? process.env.SEQUENCE_DURATION : 60; 
     this.targetDuration = {};
     this.targetAudioDuration = {};
     this.previousVod = null;

--- a/index.js
+++ b/index.js
@@ -206,6 +206,7 @@ class HLSVod {
     const targetDuration = this._determineTargetDuration(this.mediaSequences[seqIdx].segments[bw]);
     let m3u8 = "#EXTM3U\n";
     m3u8 += "#EXT-X-VERSION:3\n";
+	m3u8 += "#EXT-X-INDEPENDENT-SEGMENTS\n";
     m3u8 += "#EXT-X-TARGETDURATION:" + targetDuration + "\n";
     m3u8 += "#EXT-X-MEDIA-SEQUENCE:" + (offset + seqIdx) + "\n";
     let discInOffset = discOffset;

--- a/index.js
+++ b/index.js
@@ -205,8 +205,8 @@ class HLSVod {
     debug(`Get live media sequence [${seqIdx}] for bw=${bw} (requested bw ${bandwidth})`);
     const targetDuration = this._determineTargetDuration(this.mediaSequences[seqIdx].segments[bw]);
     let m3u8 = "#EXTM3U\n";
-    m3u8 += "#EXT-X-VERSION:3\n";
-	m3u8 += "#EXT-X-INDEPENDENT-SEGMENTS\n";
+    m3u8 += "#EXT-X-VERSION:6\n";
+	m3u8 += "#EXT-X-KEY:METHOD=NONE\n";
     m3u8 += "#EXT-X-TARGETDURATION:" + targetDuration + "\n";
     m3u8 += "#EXT-X-MEDIA-SEQUENCE:" + (offset + seqIdx) + "\n";
     let discInOffset = discOffset;


### PR DESCRIPTION
In interest of tuning the stream based on playout environment, it would be helpful to allow overriding the SEGMENT duration. If there are maximum/minimum SEGMENT_DURATIONS then we can override in the constructor to prevent out-of-range or non-numeric values