### PR TITLE
Fix: audio sequence bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -962,7 +962,11 @@ class HLSVod {
                 reject("Internal datastructure error");
                 return;
               }
-              sequence[bwIdx].push(this.segments[bwIdx][segIdx]);
+              let seg = this.segments[bwIdx][segIdx];
+              if (!seg) {
+                debug(segIdx, `WARNING! The sequence[bw=${bwIdx}] pushed seg=${seg}`);
+              }
+              sequence[bwIdx].push(seg);
             }
             if (audioGroupId) {
               const audioGroupIds = Object.keys(this.audioSegments);
@@ -977,7 +981,11 @@ class HLSVod {
                   if (!audioSequence[audioGroupId][audioLang]) {
                     audioSequence[audioGroupId][audioLang] = [];
                   }
-                  audioSequence[audioGroupId][audioLang].push(this.audioSegments[audioGroupId][audioLang][segIdx]);
+                  let seg = this.audioSegments[audioGroupId][audioLang][segIdx];
+                  if (!seg) {
+                    debug(segIdx, `WARNING! The audioSequence[id=${audioGroupId}][lang=${audioLang}] pushed seg=${seg}`);
+                  }
+                  audioSequence[audioGroupId][audioLang].push(seg);
                 }
               }
             }
@@ -1056,6 +1064,9 @@ class HLSVod {
                   }
 
                   if (seqDur < this.SEQUENCE_DURATION) {
+                    if (!seg) {
+                      debug(segIdxVideo, `WARNING! The _sequence[bw=${_bw}] pushed seg=${seg}`);
+                    }
                     _sequence[_bw].push(seg);
                   }
                 });
@@ -1072,6 +1083,9 @@ class HLSVod {
                       }
                       const seq_seg = this.audioSegments[groupId][lang][segIdxVideo];
                       if (seqDur < this.SEQUENCE_DURATION) {
+                        if (!seq_seg) {
+                          debug(segIdxVideo, `WARNING! The _audioSequence[id=${groupId}][lang=${lang}] pushed seg=${seq_seg}`);
+                        }
                         _audioSequence[groupId][lang].push(seq_seg);
                       }
                     });
@@ -1093,6 +1107,9 @@ class HLSVod {
                   if (seg && seg.duration && _bw === bw) {
                     totalSeqDurVideo += seg.duration;
                   }
+                  if (!seg) {
+                    debug(segIdxVideo, `WARNING! The _sequence[bw=${_bw}] pushed seg=${seg}`);
+                  }
                   _sequence[_bw].push(seg);
                 });
                 if (audioGroupId) {
@@ -1107,6 +1124,9 @@ class HLSVod {
                         _audioSequence[groupId][lang] = [];
                       }
                       const seq_seg = this.audioSegments[groupId][lang][segIdxVideo];
+                      if (!seq_seg) {
+                        debug(segIdxVideo, `WARNING! The _audioSequence[id=${groupId}][lang=${lang}] pushed seg=${seq_seg}`);
+                      }
                       _audioSequence[groupId][lang].push(seq_seg);
                     });
                   });
@@ -1123,9 +1143,9 @@ class HLSVod {
                   let seg = _sequence[bw].shift();
                   if (!seg) {
                     // Should not happen, debug
-                    console.error(`The _sequence[bw=${bw}] shifted seg=${seg}`);
+                    debug(`WARNING! The _sequence[bw=${bw}] shifted seg=${seg}`);
                   } else {
-                    while (!seg.duration && _sequence[bw].length > 0) {
+                    while (seg && !seg.duration && _sequence[bw].length > 0) {
                       incrementDiscSeqCount = true;
                       seg = _sequence[bw].shift();
                     }
@@ -1149,9 +1169,9 @@ class HLSVod {
                       let seg = _audioSequence[groupId][lang].shift();
                       if (!seg) {
                         // Should not happen, debug
-                        console.error(`error! The _audioSequence[id=${groupId}][lang=${lang}] shifted seg=${seg}`);
+                        debug(`WARNING! The _audioSequence[id=${groupId}][lang=${lang}] shifted seg=${seg}`);
                       } else {
-                        while (!seg.duration && _audioSequence[groupId][lang].length > 0) {
+                        while (seg && !seg.duration && _audioSequence[groupId][lang].length > 0) {
                           seg = _audioSequence[groupId][lang].shift();
                         }
                       }

--- a/index.js
+++ b/index.js
@@ -1062,7 +1062,6 @@ class HLSVod {
                   if (seg && seg.duration && _bw === bw) {
                     seqDur += seg.duration;
                   }
-
                   if (seqDur < this.SEQUENCE_DURATION) {
                     if (!seg) {
                       debug(segIdxVideo, `WARNING! The _sequence[bw=${_bw}] pushed seg=${seg}`);
@@ -1150,7 +1149,6 @@ class HLSVod {
                       seg = _sequence[bw].shift();
                     }
                   }
-
                   if (seg && seg.duration) {
                     timeToRemove = seg.duration;
                   }

--- a/index.js
+++ b/index.js
@@ -1077,7 +1077,9 @@ class HLSVod {
                     });
                   });
                 }
-                segIdxVideo++;
+                if (seqDur < this.SEQUENCE_DURATION) {
+                  segIdxVideo++;
+                }
               }
             } else {
               // Creating the rest of the sequences
@@ -1150,7 +1152,6 @@ class HLSVod {
                         console.error(`error! The _audioSequence[id=${groupId}][lang=${lang}] shifted seg=${seg}`);
                       } else {
                         while (!seg.duration && _audioSequence[groupId][lang].length > 0) {
-                          incrementDiscSeqCount = true;
                           seg = _audioSequence[groupId][lang].shift();
                         }
                       }
@@ -1171,6 +1172,11 @@ class HLSVod {
             audioSequences.push(_audioSequence);
 
             this.mediaSequenceValues[seqIndex] = totalRemovedSegments;
+            if (seqIndex === 0) {
+              // Compensate for hlsvod loaded after another.
+              totalRemovedSegments++;
+              this.mediaSequenceValues[seqIndex] = totalRemovedSegments;
+            }
             this.discontinuities[seqIndex] = totalRemovedDiscTags;
             sequence = _sequence;
             audioSequence = _audioSequence;

--- a/index.js
+++ b/index.js
@@ -888,17 +888,11 @@ class HLSVod {
       let totalRemovedDiscTags = 0;
       let totalRemovedSegments = 0;
       let totalSeqDurVideo = 0;
-      let totalSeqDurAudio = 0;
       let duration = 0;
       const bw = this._getFirstBwWithSegments();
+      const audioGroupId = this._getFirstAudioGroupWithSegments();
       let sequence = {};
       let audioSequence = {};
-
-      const audioGroupId = this._getFirstAudioGroupWithSegments();
-      let audioLang = null;
-      if (audioGroupId) {
-        audioLang = this._getFirstAudioLanguageWithSegments(audioGroupId);
-      }
 
       // Remove all double discontinuities (video)
       const bandwidths = Object.keys(this.segments);
@@ -1032,13 +1026,13 @@ class HLSVod {
         const videoSequences = [];
         const audioSequences = [];
         let segIdxVideo = 0;
-        let segIdxAudio = 0;
         const SIZE = this.segments[bw].length;
         // Process Video Segments
-        while (this.segments[bw][segIdxVideo] && segIdxVideo != SIZE) {
+        while (this.segments[bw][segIdxVideo] && segIdxVideo < SIZE) {
           try {
             totalSeqDurVideo = 0;
             const _sequence = JSON.parse(JSON.stringify(sequence));
+            const _audioSequence = JSON.parse(JSON.stringify(audioSequence));
             if (_sequence[bw] && _sequence[bw].length > 0) {
               let temp = 0;
               _sequence[bw].forEach((seg) => {
@@ -1048,157 +1042,152 @@ class HLSVod {
               });
               totalSeqDurVideo = temp;
             }
-            let prevTotalSeqDurVideo = totalSeqDurVideo;
-            let prevSegIdx = segIdxVideo;
-            // 1 - Add new segments until we overflow (per variant)
-            bandwidths.forEach((_bw) => {
-              segIdxVideo = prevSegIdx;
-              totalSeqDurVideo = prevTotalSeqDurVideo;
-              if (!_sequence[_bw]) {
-                _sequence[_bw] = [];
-              }
-              while (totalSeqDurVideo < this.SEQUENCE_DURATION && segIdxVideo != SIZE) {
-                // Push segment...
-                const seg = this.segments[_bw][segIdxVideo];
-                if (seg && seg.duration) {
-                  totalSeqDurVideo += seg.duration;
+            if (segIdxVideo === 0) {
+              // Create the very first sequence. (No need to remove any segments)
+              let seqDur = 0;
+              while (seqDur < this.SEQUENCE_DURATION && segIdxVideo < SIZE) {
+                bandwidths.forEach((_bw) => {
+                  if (!_sequence[_bw]) {
+                    _sequence[_bw] = [];
+                  }
+                  const seg = this.segments[_bw][segIdxVideo];
+                  if (seg && seg.duration && _bw === bw) {
+                    seqDur += seg.duration;
+                  }
+
+                  if (seqDur < this.SEQUENCE_DURATION) {
+                    _sequence[_bw].push(seg);
+                  }
+                });
+                if (audioGroupId) {
+                  const audioGroupIds = Object.keys(this.audioSegments);
+                  audioGroupIds.forEach((groupId) => {
+                    if (!_audioSequence[groupId]) {
+                      _audioSequence[groupId] = {};
+                    }
+                    const audioLangs = Object.keys(this.audioSegments[groupId]);
+                    audioLangs.forEach((lang) => {
+                      if (!_audioSequence[groupId][lang]) {
+                        _audioSequence[groupId][lang] = [];
+                      }
+                      const seq_seg = this.audioSegments[groupId][lang][segIdxVideo];
+                      if (seqDur < this.SEQUENCE_DURATION) {
+                        _audioSequence[groupId][lang].push(seq_seg);
+                      }
+                    });
+                  });
                 }
-                _sequence[_bw].push(seg);
                 segIdxVideo++;
               }
-            });
-            // 2 - Shift excess segments and keep count of what has been removed (per variant)
-            while (totalSeqDurVideo >= this.SEQUENCE_DURATION) {
-              let timeToRemove = 0;
-              let incrementDiscSeqCount = false;
-
-              bandwidths.forEach((bw) => {
-                let seg = _sequence[bw].shift();
-                while (!seg || !seg.duration) {
-                  incrementDiscSeqCount = true;
-                  seg = _sequence[bw].shift();
+            } else {
+              // Creating the rest of the sequences
+              // 1 - Add new segments until we overflow (per variant)
+              while (totalSeqDurVideo < this.SEQUENCE_DURATION && segIdxVideo < SIZE) {
+                bandwidths.forEach((_bw) => {
+                  if (!_sequence[_bw]) {
+                    _sequence[_bw] = [];
+                  }
+                  const seg = this.segments[_bw][segIdxVideo];
+                  if (seg && seg.duration && _bw === bw) {
+                    totalSeqDurVideo += seg.duration;
+                  }
+                  _sequence[_bw].push(seg);
+                });
+                if (audioGroupId) {
+                  const audioGroupIds = Object.keys(this.audioSegments);
+                  audioGroupIds.forEach((groupId) => {
+                    if (!_audioSequence[groupId]) {
+                      _audioSequence[groupId] = {};
+                    }
+                    const audioLangs = Object.keys(this.audioSegments[groupId]);
+                    audioLangs.forEach((lang) => {
+                      if (!_audioSequence[groupId][lang]) {
+                        _audioSequence[groupId][lang] = [];
+                      }
+                      const seq_seg = this.audioSegments[groupId][lang][segIdxVideo];
+                      _audioSequence[groupId][lang].push(seq_seg);
+                    });
+                  });
                 }
-                if (seg && seg.duration) {
-                  timeToRemove = seg.duration;
-                }
-              });
-
-              if (timeToRemove) {
-                totalSeqDurVideo -= timeToRemove;
-                totalRemovedSegments++;
+                segIdxVideo++;
               }
-              if (incrementDiscSeqCount) {
-                totalRemovedDiscTags++;
+              let shiftOnce = true;
+              // 2 - Shift excess segments and keep count of what has been removed (per variant)
+              while (totalSeqDurVideo >= this.SEQUENCE_DURATION || (shiftOnce && segIdxVideo !== 0)) {
+                shiftOnce = false;
+                let timeToRemove = 0;
+                let incrementDiscSeqCount = false;
+                bandwidths.forEach((bw) => {
+                  let seg = _sequence[bw].shift();
+                  if (!seg) {
+                    // Should not happen, debug
+                    console.error(`The _sequence[bw=${bw}] shifted seg=${seg}`);
+                  } else {
+                    while (!seg.duration && _sequence[bw].length > 0) {
+                      incrementDiscSeqCount = true;
+                      seg = _sequence[bw].shift();
+                    }
+                  }
+
+                  if (seg && seg.duration) {
+                    timeToRemove = seg.duration;
+                  }
+                });
+                if (audioGroupId) {
+                  const audioGroupIds = Object.keys(this.audioSegments);
+                  audioGroupIds.forEach((groupId) => {
+                    if (!_audioSequence[groupId]) {
+                      _audioSequence[groupId] = {};
+                    }
+                    const audioLangs = Object.keys(this.audioSegments[groupId]);
+                    audioLangs.forEach((lang) => {
+                      if (!_audioSequence[groupId][lang]) {
+                        _audioSequence[groupId][lang] = [];
+                      }
+                      let seg = _audioSequence[groupId][lang].shift();
+                      if (!seg) {
+                        // Should not happen, debug
+                        console.error(`error! The _audioSequence[id=${groupId}][lang=${lang}] shifted seg=${seg}`);
+                      } else {
+                        while (!seg.duration && _audioSequence[groupId][lang].length > 0) {
+                          incrementDiscSeqCount = true;
+                          seg = _audioSequence[groupId][lang].shift();
+                        }
+                      }
+                    });
+                  });
+                }
+                if (timeToRemove) {
+                  totalSeqDurVideo -= timeToRemove;
+                  totalRemovedSegments++;
+                }
+                if (incrementDiscSeqCount) {
+                  totalRemovedDiscTags++;
+                }
               }
             }
 
             videoSequences.push(_sequence);
+            audioSequences.push(_audioSequence);
 
             this.mediaSequenceValues[seqIndex] = totalRemovedSegments;
-            if (seqIndex === 0) {
-              // Compensate for hlsvod loaded after another.
-              totalRemovedSegments++;
-              this.mediaSequenceValues[seqIndex] = totalRemovedSegments;
-            }
             this.discontinuities[seqIndex] = totalRemovedDiscTags;
             sequence = _sequence;
+            audioSequence = _audioSequence;
             seqIndex++;
           } catch (err) {
             console.error(err);
           }
         }
-
-        if (audioGroupId) {
-          // Process Audio Segments
-          while (this.audioSegments[audioGroupId][audioLang][segIdxAudio] && segIdxAudio != SIZE) {
-            totalSeqDurAudio = 0;
-            const _audioSequence = JSON.parse(JSON.stringify(audioSequence));
-            if (_audioSequence[audioGroupId] && _audioSequence[audioGroupId][audioLang] && _audioSequence[audioGroupId][audioLang].length > 0) {
-              let temp = 0;
-              _audioSequence[audioGroupId][audioLang].forEach((seg) => {
-                if (seg && seg.duration) {
-                  temp += seg.duration;
-                }
-              });
-              totalSeqDurAudio = temp;
-            }
-            let prevTotalSeqDur = totalSeqDurAudio;
-            let prevSegIdx = segIdxAudio;
-            // 1 - Add new segments until we overflow (per variant)
-            const audioGroupIds = Object.keys(this.audioSegments);
-            audioGroupIds.forEach((groupId) => {
-              if (!_audioSequence[groupId]) {
-                _audioSequence[groupId] = {};
-              }
-              const audioLangs = Object.keys(this.audioSegments[groupId]);
-              audioLangs.forEach((lang) => {
-                if (!_audioSequence[groupId][lang]) {
-                  _audioSequence[groupId][lang] = [];
-                }
-                segIdxAudio = prevSegIdx;
-                totalSeqDurAudio = prevTotalSeqDur;
-                while (totalSeqDurAudio < this.SEQUENCE_DURATION && segIdxAudio != SIZE) {
-                  // Push segment...
-                  const seg = this.audioSegments[groupId][lang][segIdxAudio];
-                  if (seg && seg.duration) {
-                    totalSeqDurAudio += seg.duration;
-                  }
-                  _audioSequence[groupId][lang].push(seg);
-                  segIdxAudio++;
-                }
-              });
-            });
-            // 2 - Shift excess segments and keep count of what has been removed (per variant)
-            while (totalSeqDurAudio >= this.SEQUENCE_DURATION) {
-              let timeToRemove = 0;
-              const audioGroupIds = Object.keys(this.audioSegments);
-
-              audioGroupIds.forEach((_group) => {
-                const audioLangs = Object.keys(this.audioSegments[_group]);
-                audioLangs.forEach((_lang) => {
-                  let seg = _audioSequence[_group][_lang].shift();
-                  while (!seg || !seg.duration) {
-                    seg = _audioSequence[_group][_lang].shift();
-                  }
-                  if (seg && seg.duration) {
-                    timeToRemove = seg.duration;
-                  }
-                });
-              });
-
-              if (timeToRemove) {
-                totalSeqDurAudio -= timeToRemove;
-              }
-            }
-
-            audioSequences.push(_audioSequence);
-            audioSequence = _audioSequence;
-          }
-        }
-        // Transfer all generated sequences to 'this.mediaSequences'
-        this.mediaSequences = videoSequences.map((videoSeq, index) => {
-          let audioSeq = {};
-          if (audioSequences.length > 0 && audioSequences[index]) {
-            audioSeq = audioSequences[index];
-          }
+        // Append newly generated video/audio sequences
+        for (let i = 0; i < videoSequences.length; i++) {
+          const vseq = videoSequences[i];
+          const aseq = audioSequences[i];
           const mseq = {
-            segments: videoSeq,
-            audioSegments: audioSeq,
+            segments: vseq,
+            audioSegments: aseq,
           };
-          return mseq;
-        });
-
-        if (totalSeqDurVideo < this.SEQUENCE_DURATION) {
-          // We are out of segments but have not reached the full duration of a sequence
-          totalSeqDurVideo = 0;
-          this.mediaSequences.push({
-            segments: sequence,
-            audioSegments: audioSequence,
-          });
-          this.mediaSequenceValues[seqIndex] = totalRemovedSegments;
-          this.discontinuities[seqIndex] = totalRemovedDiscTags;
-          sequence = {};
-          audioSequence = {};
+          this.mediaSequences.push(mseq);
         }
       }
 

--- a/spec/hlsvod_spec.js
+++ b/spec/hlsvod_spec.js
@@ -1,6 +1,7 @@
 const HLSVod = require("../index.js");
 const fs = require("fs");
 const m3u8 = require("@eyevinn/m3u8");
+const { ConsoleReporter } = require("jasmine");
 const Readable = require("stream").Readable;
 
 describe("HLSVod standalone", () => {
@@ -2475,24 +2476,23 @@ describe("HLSVod with set option-> sequenceAlwaysContainNewSegments", () => {
         };
 
         const expectedMseqVals = {
-          0: 2,
-          1: 4,
-          2: 5,
-          3: 6,
-          4: 7,
-          5: 8,
-          6: 9,
-          7: 10,
-          8: 11,
-          9: 12,
-          10: 13,
-          11: 14,
-          12: 15,
-          13: 15,
+          0: 0,
+          1: 1,
+          2: 3,
+          3: 4,
+          4: 5,
+          5: 6,
+          6: 7,
+          7: 8,
+          8: 9,
+          9: 10,
+          10: 11,
+          11: 12,
+          12: 13,
         };
         const expectedDseqVals = {
           0: 0,
-          1: 1,
+          1: 0,
           2: 1,
           3: 1,
           4: 1,
@@ -2504,7 +2504,6 @@ describe("HLSVod with set option-> sequenceAlwaysContainNewSegments", () => {
           10: 1,
           11: 1,
           12: 1,
-          13: 1,
         };
         const expectedLastMseqTopAndBottomSegURI = {
           top: "http://mock.com/level0/seg_44.ts",
@@ -2538,14 +2537,13 @@ describe("HLSVod with set option-> sequenceAlwaysContainNewSegments", () => {
         });
 
         const expectedMseqVals = {
-          0: 2,
-          1: 4,
-          2: 6,
-          3: 8,
-          4: 10,
-          5: 11,
-          6: 12,
-          7: 12,
+          0: 0,
+          1: 2,
+          2: 4,
+          3: 6,
+          4: 8,
+          5: 9,
+          6: 10,
         };
         const expectedDseqVals = {
           0: 0,
@@ -2555,19 +2553,18 @@ describe("HLSVod with set option-> sequenceAlwaysContainNewSegments", () => {
           4: 1,
           5: 2,
           6: 2,
-          7: 2,
         };
         const expectedTopAndBottomSegURIList = [
           {
-            top: "http://mock.com/level0/seg_46.ts",
-            bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00001.ts",
+            top: "http://mock.com/level0/seg_45.ts",
+            bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00000.ts",
           },
           {
-            top: "http://mock.com/level0/seg_48.ts",
+            top: "http://mock.com/level0/seg_47.ts",
             bottom: "http://mock.com/level0/seg_0000.ts",
           },
           {
-            top: "http://mock.com/level0/seg_50.ts",
+            top: "http://mock.com/level0/seg_49.ts",
             bottom: "http://mock.com/level0/seg_0001.ts",
           },
         ];
@@ -2739,9 +2736,11 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
   });
 
   it("set to true, will never create media sequences that have the same last segment", (done) => {
-    mockVod = new HLSVod("http://mock.com/mock.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: true });
-    mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: true });
-    mockVod3 = new HLSVod("http://mock.com/mock3.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: true });
+    let uri =
+      "https://virtual-channels-functions-alb.b17g-dev.net/stitch/master.m3u8?payload=eyJ1cmkiOiJodHRwczovL2xicy11c3AtaGxzLXZvZC5jbW9yZS5zZS92b2QvYmFjZmUvQ2hlcnJpZV9jbGVhbjI0OWZfMTM3MjQ3KDEzNzI0NzQ0X0lTTVVTUCkuaXNtL0NoZXJyaWVfY2xlYW4yNDlmXzEzNzI0NygxMzcyNDc0NF9JU01VU1ApLm0zdTg/aGxzX25vX211bHRpcGxleD1mYWxzZSZmaWx0ZXI9KHR5cGUhPVwidGV4dHN0cmVhbVwiKSIsImJyZWFrcyI6W119:0";
+    mockVod = new HLSVod("http://mock.com/mock.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
+    mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
+    mockVod3 = new HLSVod("http://mock.com/mock3.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
     mockVod
       .load(mock1_MasterManifest, mock1_MediaManifest, mock1_AudioManifest)
       .then(() => {
@@ -2761,24 +2760,23 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
           bottom: lastMseqAudio[lastMseqAudio.length - 1].uri,
         };
         const expectedMseqVals = {
-          0: 2,
-          1: 4,
-          2: 5,
-          3: 6,
-          4: 7,
-          5: 8,
-          6: 9,
-          7: 10,
-          8: 11,
-          9: 12,
-          10: 13,
-          11: 14,
-          12: 15,
-          13: 15,
+          0: 0,
+          1: 1,
+          2: 3,
+          3: 4,
+          4: 5,
+          5: 6,
+          6: 7,
+          7: 8,
+          8: 9,
+          9: 10,
+          10: 11,
+          11: 12,
+          12: 13,
         };
         const expectedDseqVals = {
           0: 0,
-          1: 1,
+          1: 0,
           2: 1,
           3: 1,
           4: 1,
@@ -2790,7 +2788,6 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
           10: 1,
           11: 1,
           12: 1,
-          13: 1,
         };
         const expectedLastMseqTopAndBottomSegURI = {
           top: "http://mock.com/level0/seg_44.ts",
@@ -2849,14 +2846,13 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
         });
 
         const expectedMseqVals = {
-          0: 2,
-          1: 4,
-          2: 6,
-          3: 8,
-          4: 10,
-          5: 11,
-          6: 12,
-          7: 12,
+          0: 0,
+          1: 2,
+          2: 4,
+          3: 6,
+          4: 8,
+          5: 9,
+          6: 10,
         };
         const expectedDseqVals = {
           0: 0,
@@ -2866,36 +2862,36 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
           4: 1,
           5: 2,
           6: 2,
-          7: 2,
         };
         const expectedTopAndBottomSegURIList = [
           {
-            top: "http://mock.com/level0/seg_46.ts",
-            bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00001.ts",
+            top: "http://mock.com/level0/seg_45.ts",
+            bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00000.ts",
           },
           {
-            top: "http://mock.com/level0/seg_48.ts",
+            top: "http://mock.com/level0/seg_47.ts",
             bottom: "http://mock.com/level0/seg_0000.ts",
           },
           {
-            top: "http://mock.com/level0/seg_50.ts",
+            top: "http://mock.com/level0/seg_49.ts",
             bottom: "http://mock.com/level0/seg_0001.ts",
           },
         ];
         const expectedTopAndBottomSegURIListAudio = [
           {
-            top: "http://mock.com/audio/seg_en_46.ts",
-            bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/audio/en-00001.ts",
+            top: "http://mock.com/audio/seg_en_45.ts",
+            bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/audio/en-00000.ts",
           },
           {
-            top: "http://mock.com/audio/seg_en_48.ts",
+            top: "http://mock.com/audio/seg_en_47.ts",
             bottom: "http://mock.com/audio/seg_en_0000.ts",
           },
           {
-            top: "http://mock.com/audio/seg_en_50.ts",
+            top: "http://mock.com/audio/seg_en_49.ts",
             bottom: "http://mock.com/audio/seg_en_0001.ts",
           },
         ];
+
         expect(mseqs).toEqual(expectedMseqVals);
         expect(dseqs).toEqual(expectedDseqVals);
         expect(topAndBottomSegURIList).toEqual(expectedTopAndBottomSegURIList);

--- a/spec/hlsvod_spec.js
+++ b/spec/hlsvod_spec.js
@@ -2736,8 +2736,8 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
   });
 
   it("set to true, will never create media sequences that have the same last segment", (done) => {
-    mockVod = new HLSVod(uri, null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
-    mockVod2 = new HLSVod(uri, null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
+    mockVod = new HLSVod("http://mock.com/mock.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
+    mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
     mockVod3 = new HLSVod("http://mock.com/mock3.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
     mockVod
       .load(mock1_MasterManifest, mock1_MediaManifest, mock1_AudioManifest)

--- a/spec/hlsvod_spec.js
+++ b/spec/hlsvod_spec.js
@@ -2736,10 +2736,8 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
   });
 
   it("set to true, will never create media sequences that have the same last segment", (done) => {
-    let uri =
-      "https://virtual-channels-functions-alb.b17g-dev.net/stitch/master.m3u8?payload=eyJ1cmkiOiJodHRwczovL2xicy11c3AtaGxzLXZvZC5jbW9yZS5zZS92b2QvYmFjZmUvQ2hlcnJpZV9jbGVhbjI0OWZfMTM3MjQ3KDEzNzI0NzQ0X0lTTVVTUCkuaXNtL0NoZXJyaWVfY2xlYW4yNDlmXzEzNzI0NygxMzcyNDc0NF9JU01VU1ApLm0zdTg/aGxzX25vX211bHRpcGxleD1mYWxzZSZmaWx0ZXI9KHR5cGUhPVwidGV4dHN0cmVhbVwiKSIsImJyZWFrcyI6W119:0";
-    mockVod = new HLSVod("http://mock.com/mock.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
-    mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
+    mockVod = new HLSVod(uri, null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
+    mockVod2 = new HLSVod(uri, null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
     mockVod3 = new HLSVod("http://mock.com/mock3.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1 });
     mockVod
       .load(mock1_MasterManifest, mock1_MediaManifest, mock1_AudioManifest)

--- a/spec/hlsvod_spec.js
+++ b/spec/hlsvod_spec.js
@@ -1,7 +1,6 @@
 const HLSVod = require("../index.js");
 const fs = require("fs");
 const m3u8 = require("@eyevinn/m3u8");
-const { ConsoleReporter } = require("jasmine");
 const Readable = require("stream").Readable;
 
 describe("HLSVod standalone", () => {

--- a/spec/hlsvod_spec.js
+++ b/spec/hlsvod_spec.js
@@ -2476,19 +2476,20 @@ describe("HLSVod with set option-> sequenceAlwaysContainNewSegments", () => {
         };
 
         const expectedMseqVals = {
-          0: 0,
-          1: 1,
-          2: 3,
-          3: 4,
-          4: 5,
-          5: 6,
-          6: 7,
-          7: 8,
-          8: 9,
-          9: 10,
-          10: 11,
-          11: 12,
-          12: 13,
+          0: 1,
+          1: 2,
+          2: 4,
+          3: 5,
+          4: 6,
+          5: 7,
+          6: 8,
+          7: 9,
+          8: 10,
+          9: 11,
+          10: 12,
+          11: 13,
+          12: 14,
+          13: 15,
         };
         const expectedDseqVals = {
           0: 0,
@@ -2504,6 +2505,7 @@ describe("HLSVod with set option-> sequenceAlwaysContainNewSegments", () => {
           10: 1,
           11: 1,
           12: 1,
+          13: 1,
         };
         const expectedLastMseqTopAndBottomSegURI = {
           top: "http://mock.com/level0/seg_44.ts",
@@ -2537,22 +2539,24 @@ describe("HLSVod with set option-> sequenceAlwaysContainNewSegments", () => {
         });
 
         const expectedMseqVals = {
-          0: 0,
+          0: 1,
           1: 2,
           2: 4,
           3: 6,
           4: 8,
-          5: 9,
-          6: 10,
+          5: 10,
+          6: 11,
+          7: 12,
         };
         const expectedDseqVals = {
           0: 0,
           1: 0,
           2: 0,
           3: 0,
-          4: 1,
-          5: 2,
+          4: 0,
+          5: 1,
           6: 2,
+          7: 2,
         };
         const expectedTopAndBottomSegURIList = [
           {
@@ -2560,14 +2564,28 @@ describe("HLSVod with set option-> sequenceAlwaysContainNewSegments", () => {
             bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00000.ts",
           },
           {
-            top: "http://mock.com/level0/seg_47.ts",
-            bottom: "http://mock.com/level0/seg_0000.ts",
+            top: "http://mock.com/level0/seg_46.ts",
+            bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00001.ts",
           },
           {
-            top: "http://mock.com/level0/seg_49.ts",
-            bottom: "http://mock.com/level0/seg_0001.ts",
+            top: "http://mock.com/level0/seg_48.ts",
+            bottom: "http://mock.com/level0/seg_0000.ts",
           },
         ];
+        const gd = (list) => {
+          let t = 0;
+          list.forEach((i) => {
+            if (i.duration) {
+              t += i.duration;
+            }
+          });
+          return t;
+        };
+        // To Verify
+        // console.log(mseqs);
+        // mockVod2.mediaSequences.forEach((seq, idx) => {
+        //   console.log(idx, seq["segments"][someBW], gd(seq["segments"][someBW]));
+        // });
         expect(mseqs).toEqual(expectedMseqVals);
         expect(dseqs).toEqual(expectedDseqVals);
         expect(topAndBottomSegURIList).toEqual(expectedTopAndBottomSegURIList);
@@ -2758,19 +2776,20 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
           bottom: lastMseqAudio[lastMseqAudio.length - 1].uri,
         };
         const expectedMseqVals = {
-          0: 0,
-          1: 1,
-          2: 3,
-          3: 4,
-          4: 5,
-          5: 6,
-          6: 7,
-          7: 8,
-          8: 9,
-          9: 10,
-          10: 11,
-          11: 12,
-          12: 13,
+          0: 1,
+          1: 2,
+          2: 4,
+          3: 5,
+          4: 6,
+          5: 7,
+          6: 8,
+          7: 9,
+          8: 10,
+          9: 11,
+          10: 12,
+          11: 13,
+          12: 14,
+          13: 15,
         };
         const expectedDseqVals = {
           0: 0,
@@ -2786,6 +2805,7 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
           10: 1,
           11: 1,
           12: 1,
+          13: 1,
         };
         const expectedLastMseqTopAndBottomSegURI = {
           top: "http://mock.com/level0/seg_44.ts",
@@ -2844,22 +2864,24 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
         });
 
         const expectedMseqVals = {
-          0: 0,
+          0: 1,
           1: 2,
           2: 4,
           3: 6,
           4: 8,
-          5: 9,
-          6: 10,
+          5: 10,
+          6: 11,
+          7: 12
         };
         const expectedDseqVals = {
           0: 0,
           1: 0,
           2: 0,
           3: 0,
-          4: 1,
-          5: 2,
+          4: 0,
+          5: 1,
           6: 2,
+          7: 2
         };
         const expectedTopAndBottomSegURIList = [
           {
@@ -2867,12 +2889,12 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
             bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00000.ts",
           },
           {
-            top: "http://mock.com/level0/seg_47.ts",
-            bottom: "http://mock.com/level0/seg_0000.ts",
+            top: "http://mock.com/level0/seg_46.ts",
+            bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00001.ts",
           },
           {
-            top: "http://mock.com/level0/seg_49.ts",
-            bottom: "http://mock.com/level0/seg_0001.ts",
+            top: "http://mock.com/level0/seg_48.ts",
+            bottom: "http://mock.com/level0/seg_0000.ts",
           },
         ];
         const expectedTopAndBottomSegURIListAudio = [
@@ -2881,12 +2903,12 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
             bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/audio/en-00000.ts",
           },
           {
-            top: "http://mock.com/audio/seg_en_47.ts",
-            bottom: "http://mock.com/audio/seg_en_0000.ts",
+            top: "http://mock.com/audio/seg_en_46.ts",
+            bottom: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/audio/en-00001.ts",
           },
           {
-            top: "http://mock.com/audio/seg_en_49.ts",
-            bottom: "http://mock.com/audio/seg_en_0001.ts",
+            top: "http://mock.com/audio/seg_en_48.ts",
+            bottom: "http://mock.com/audio/seg_en_0000.ts",
           },
         ];
 
@@ -3083,6 +3105,467 @@ describe("HLSVod for demuxed audio, with set option-> sequenceAlwaysContainNewSe
         expect(dseqs).toEqual(expectedDseqVals);
         expect(topAndBottomSegURIList).toEqual(expectedTopAndBottomSegURIList);
         expect(topAndBottomSegURIListAudio).toEqual(expectedTopAndBottomSegURIListAudio);
+        done();
+      });
+  });
+});
+
+describe("HLSVod when loading mux vod after demux vod, with set option-> sequenceAlwaysContainNewSegments", () => {
+  let mock1_MasterManifest;
+  let mock1_MediaManifest;
+  let mock1_AudioManifest;
+  let mock2_MasterManifest;
+  let mock2_MediaManifest;
+  let mock2_AudioManifest;
+
+  beforeEach(() => {
+    mock1_MasterManifest = function () {
+      return fs.createReadStream("testvectors/hls_always_0_demux/master.m3u8");
+    };
+    mock1_MediaManifest = function (bandwidth) {
+      return fs.createReadStream("testvectors/hls_always_0_demux/" + bandwidth + ".m3u8");
+    };
+    mock1_AudioManifest = function (groupId, lang) {
+      if (groupId && lang) {
+        return fs.createReadStream(`testvectors/hls_always_0_demux/${groupId}-${lang}.m3u8`);
+      } else {
+        return fs.createReadStream(`testvectors/hls_always_0_demux/${groupId}.m3u8`);
+      }
+    };
+
+    mock2_MasterManifest = function () {
+      return fs.createReadStream("testvectors/hls_always_1/master.m3u8");
+    };
+    mock2_MediaManifest = function (bandwidth) {
+      return fs.createReadStream("testvectors/hls_always_1/" + bandwidth + ".m3u8");
+    };
+    mock2_AudioManifest = function (groupId, lang) {
+      if (groupId && lang) {
+        return fs.createReadStream(`testvectors/hls_always_1/${groupId}-${lang}.m3u8`);
+      } else {
+        return fs.createReadStream(`testvectors/hls_always_1/${groupId}.m3u8`);
+      }
+    };
+  });
+
+  it("set to true, will have null segments in the first couple of sequences", (done) => {
+    let bool = 1;
+    mockVod = new HLSVod("http://mock.com/mock.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod3 = new HLSVod("http://mock.com/mock3.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod
+      .load(mock1_MasterManifest, mock1_MediaManifest, mock1_AudioManifest)
+      .then(() => {
+        return mockVod2.loadAfter(mockVod, mock2_MasterManifest, mock2_MediaManifest, mock2_AudioManifest);
+      })
+      .then(() => {
+        const expectedSeqAudioSegs = [
+          {
+            duration: 6.006,
+            uri: "http://mock.com/audio/seg_en_50.ts",
+          },
+          {
+            duration: 6.006,
+            uri: "http://mock.com/audio/seg_en_51.ts",
+          },
+          {
+            duration: 6.006,
+            uri: "http://mock.com/audio/seg_en_52.ts",
+          },
+          {
+            discontinuity: true,
+            daterange: null,
+          },
+          null,
+          null,
+          null,
+          null,
+          undefined,
+        ];
+        const expectedSeqVideoSegs = [
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_50.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_51.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_52.ts",
+          },
+          {
+            discontinuity: true,
+            daterange: null,
+          },
+          {
+            duration: 10.88,
+            timelinePosition: null,
+            cue: {
+              out: true,
+              cont: null,
+              scteData: null,
+              in: false,
+              duration: 15.120000000000001,
+              assetData: null,
+            },
+            uri: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00000.ts",
+          },
+          {
+            duration: 4.24,
+            timelinePosition: null,
+            cue: null,
+            uri: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00001.ts",
+          },
+          {
+            discontinuity: true,
+          },
+          {
+            duration: 11,
+            timelinePosition: null,
+            cue: {
+              out: false,
+              cont: null,
+              scteData: null,
+              in: true,
+              duration: 0,
+              assetData: null,
+            },
+            uri: "http://mock.com/level0/seg_0000.ts",
+          },
+          {
+            duration: 12,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_0001.ts",
+          },
+        ];
+        let sq = 3;
+        let _bw = Object.keys(mockVod2.mediaSequences[sq].segments)[0];
+        const seqAudioSegments = mockVod2.mediaSequences[sq].audioSegments["aac"]["en"];
+        const seqVideoSegments = mockVod2.mediaSequences[sq].segments[_bw];
+        expect(seqVideoSegments).toEqual(expectedSeqVideoSegs);
+        expect(seqAudioSegments).toEqual(expectedSeqAudioSegs);
+        done();
+      });
+  });
+  it("set to true, will have null segments in the later sequences", (done) => {
+    let bool = 1;
+    mockVod = new HLSVod("http://mock.com/mock2.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod2 = new HLSVod("http://mock.com/mock.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod3 = new HLSVod("http://mock.com/mock3.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod
+      .load(mock2_MasterManifest, mock2_MediaManifest, mock2_AudioManifest)
+      .then(() => {
+        return mockVod2.loadAfter(mockVod, mock1_MasterManifest, mock1_MediaManifest, mock1_AudioManifest);
+      })
+      .then(() => {
+        const expectedSeqAudioSegs = [
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_48.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_49.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_50.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_51.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_52.ts" },
+          null,
+          null,
+          null,
+          null,
+          undefined,
+        ];
+        const expectedSeqVideoSegs = [
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_44.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_45.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_46.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_47.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_48.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_49.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_50.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_51.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_52.ts",
+          },
+        ];
+        let sq = 17;
+        let _bw = Object.keys(mockVod2.mediaSequences[sq].segments)[0];
+        const seqAudioSegments = mockVod2.mediaSequences[sq].audioSegments["aac"]["en"];
+        const seqVideoSegments = mockVod2.mediaSequences[sq].segments[_bw];
+        expect(seqVideoSegments).toEqual(expectedSeqVideoSegs);
+        expect(seqAudioSegments).toEqual(expectedSeqAudioSegs);
+        done();
+      });
+  });
+});
+
+describe("HLSVod when loading mux vod after demux vod, with set option-> sequenceAlwaysContainNewSegments", () => {
+  let mock1_MasterManifest;
+  let mock1_MediaManifest;
+  let mock1_AudioManifest;
+  let mock2_MasterManifest;
+  let mock2_MediaManifest;
+  let mock2_AudioManifest;
+
+  beforeEach(() => {
+    mock1_MasterManifest = function () {
+      return fs.createReadStream("testvectors/hls_always_0_demux/master.m3u8");
+    };
+    mock1_MediaManifest = function (bandwidth) {
+      return fs.createReadStream("testvectors/hls_always_0_demux/" + bandwidth + ".m3u8");
+    };
+    mock1_AudioManifest = function (groupId, lang) {
+      if (groupId && lang) {
+        return fs.createReadStream(`testvectors/hls_always_0_demux/${groupId}-${lang}.m3u8`);
+      } else {
+        return fs.createReadStream(`testvectors/hls_always_0_demux/${groupId}.m3u8`);
+      }
+    };
+
+    mock2_MasterManifest = function () {
+      return fs.createReadStream("testvectors/hls_always_1/master.m3u8");
+    };
+    mock2_MediaManifest = function (bandwidth) {
+      return fs.createReadStream("testvectors/hls_always_1/" + bandwidth + ".m3u8");
+    };
+    mock2_AudioManifest = function (groupId, lang) {
+      if (groupId && lang) {
+        return fs.createReadStream(`testvectors/hls_always_1/${groupId}-${lang}.m3u8`);
+      } else {
+        return fs.createReadStream(`testvectors/hls_always_1/${groupId}.m3u8`);
+      }
+    };
+  });
+
+  it("set to false, will have null segments in the first couple of sequences", (done) => {
+    let bool = 0;
+    mockVod = new HLSVod("http://mock.com/mock.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod3 = new HLSVod("http://mock.com/mock3.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod
+      .load(mock1_MasterManifest, mock1_MediaManifest, mock1_AudioManifest)
+      .then(() => {
+        return mockVod2.loadAfter(mockVod, mock2_MasterManifest, mock2_MediaManifest, mock2_AudioManifest);
+      })
+      .then(() => {
+        const expectedSeqAudioSegs = [
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_48.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_49.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_50.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_51.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_52.ts" },
+          { discontinuity: true, daterange: null },
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+        ];
+        const expectedSeqVideoSegs = [
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_48.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_49.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_50.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_51.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_52.ts",
+          },
+          { discontinuity: true, daterange: null },
+          {
+            duration: 10.88,
+            timelinePosition: null,
+            cue: {
+              out: true,
+              cont: null,
+              scteData: null,
+              in: false,
+              duration: 15.120000000000001,
+              assetData: null,
+            },
+            uri: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00000.ts",
+          },
+          {
+            duration: 4.24,
+            timelinePosition: null,
+            cue: null,
+            uri: "https://maitv-vod.lab.eyevinn.technology/ads/apotea-15s.mp4/level0/2000-00001.ts",
+          },
+          { discontinuity: true },
+          {
+            duration: 11,
+            timelinePosition: null,
+            cue: {
+              out: false,
+              cont: null,
+              scteData: null,
+              in: true,
+              duration: 0,
+              assetData: null,
+            },
+            uri: "http://mock.com/level0/seg_0000.ts",
+          },
+        ];
+        let sq = 3;
+        let _bw = Object.keys(mockVod2.mediaSequences[sq].segments)[0];
+        const seqAudioSegments = mockVod2.mediaSequences[sq].audioSegments["aac"]["en"];
+        const seqVideoSegments = mockVod2.mediaSequences[sq].segments[_bw];
+        expect(seqVideoSegments).toEqual(expectedSeqVideoSegs);
+        expect(seqAudioSegments).toEqual(expectedSeqAudioSegs);
+        done();
+      });
+  });
+  it("set to false, will have null segments in the later sequences", (done) => {
+    let bool = 0;
+    mockVod = new HLSVod("http://mock.com/mock2.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod2 = new HLSVod("http://mock.com/mock.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod3 = new HLSVod("http://mock.com/mock3.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: bool });
+    mockVod
+      .load(mock2_MasterManifest, mock2_MediaManifest, mock2_AudioManifest)
+      .then(() => {
+        return mockVod2.loadAfter(mockVod, mock1_MasterManifest, mock1_MediaManifest, mock1_AudioManifest);
+      })
+      .then(() => {
+        const expectedSeqAudioSegs = [
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_49.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_50.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_51.ts" },
+          { duration: 6.006, uri: "http://mock.com/audio/seg_en_52.ts" },
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+        ];
+        const expectedSeqVideoSegs = [
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_44.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_45.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_46.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_47.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_48.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_49.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_50.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_51.ts",
+          },
+          {
+            duration: 6.006,
+            timelinePosition: null,
+            cue: null,
+            uri: "http://mock.com/level0/seg_52.ts",
+          },
+        ];
+        let sq = 18;
+        let _bw = Object.keys(mockVod2.mediaSequences[sq].segments)[0];
+        const seqAudioSegments = mockVod2.mediaSequences[sq].audioSegments["aac"]["en"];
+        const seqVideoSegments = mockVod2.mediaSequences[sq].segments[_bw];
+        expect(seqVideoSegments).toEqual(expectedSeqVideoSegs);
+        expect(seqAudioSegments).toEqual(expectedSeqAudioSegs);
         done();
       });
   });


### PR DESCRIPTION
This PR fixes #56 

The second handler for _createMediaSequences has been reworked to handle audio sequences the same way the original handler does it. i.e. If the video part appends a segment from a certain index, then the audio part should also push an audio segment from the same index.

this.audioSegments may still get 'null' appended to the segment lists when you load audio-trackless VOD after VOD with audio-tracks, as what happens in the original handler, only now it doesn't result in a TypeError. 