### PR TITLE
fix: use 5 decimals for segment duration

### DIFF
--- a/index.js
+++ b/index.js
@@ -674,7 +674,7 @@ class HLSVod {
             m3u8 += "#EXT-X-CUE-IN" + "\n";
           }
           if (v.uri) {
-            m3u8 += "#EXTINF:" + v.duration.toFixed(3) + ",\n";
+            m3u8 += "#EXTINF:" + v.duration.toFixed(5) + ",\n";
             if (v.byteRange) {
               m3u8 += `#EXT-X-BYTERANGE:${v.byteRange}\n`;
             }
@@ -793,7 +793,7 @@ class HLSVod {
             }
           }
           if (v.uri) {
-            m3u8 += "#EXTINF:" + v.duration.toFixed(3) + ",\n";
+            m3u8 += "#EXTINF:" + v.duration.toFixed(5) + ",\n";
             if (v.byteRange) {
               m3u8 += `#EXT-X-BYTERANGE:${v.byteRange}\n`;
             }

--- a/spec/hlsvod_byterange_spec.js
+++ b/spec/hlsvod_byterange_spec.js
@@ -41,7 +41,7 @@ describe("HLSVod CMAF with BYTERANGE standalone", () => {
         let lines = m3u8.split("\n");
 
         expect(lines[6]).toEqual('#EXT-X-MAP:URI="http://mock.com/media/VIDEO_e4da5fcd-5ffc-4713-bcdd-95ea579d790b_sdr_720p-video-avc1.mp4",BYTERANGE="731@0"')
-        expect(lines[7]).toEqual("#EXTINF:6.000,");
+        expect(lines[7]).toEqual("#EXTINF:6.00000,");
         expect(lines[8]).toEqual("#EXT-X-BYTERANGE:126323@1291");
         expect(lines[9]).toEqual("http://mock.com/media/VIDEO_e4da5fcd-5ffc-4713-bcdd-95ea579d790b_sdr_720p-video-avc1.mp4");
 
@@ -49,7 +49,7 @@ describe("HLSVod CMAF with BYTERANGE standalone", () => {
         let linesAudio = m3u8Audio.split("\n");
 
         expect(linesAudio[6]).toEqual('#EXT-X-MAP:URI="http://mock.com/media/VIDEO_e4da5fcd-5ffc-4713-bcdd-95ea579d790b_stereo_aac-audio-ja-mp4a.mp4",BYTERANGE="660@0"')
-        expect(linesAudio[7]).toEqual("#EXTINF:5.995,");
+        expect(linesAudio[7]).toEqual("#EXTINF:5.99467,");
         expect(linesAudio[8]).toEqual("#EXT-X-BYTERANGE:97142@1220");
         expect(linesAudio[9]).toEqual("http://mock.com/media/VIDEO_e4da5fcd-5ffc-4713-bcdd-95ea579d790b_stereo_aac-audio-ja-mp4a.mp4");
 

--- a/spec/hlsvod_spec.js
+++ b/spec/hlsvod_spec.js
@@ -2120,7 +2120,7 @@ describe("HLSVod time metadata", () => {
       .then(() => {
         let m3u8 = mockVod.getLiveMediaSequences(0, "2497000", 0);
         let m = m3u8.match(
-          '#EXT-X-PROGRAM-DATE-TIME:2020-11-21T10:00:00.000Z\n#EXT-X-DATERANGE:START-DATE="2020-11-21T10:00:00.000Z",END-DATE="2020-11-21T11:00:00.000Z",DURATION=3600.000\n#EXTINF:9.000,'
+          '#EXT-X-PROGRAM-DATE-TIME:2020-11-21T10:00:00.000Z\n#EXT-X-DATERANGE:START-DATE="2020-11-21T10:00:00.000Z",END-DATE="2020-11-21T11:00:00.000Z",DURATION=3600.000\n#EXTINF:9.00000,'
         );
         expect(m).not.toBeNull();
 


### PR DESCRIPTION
Reduce the chance of rounding errors by increasing segment duration to 5 decimals (from 3)