### PR TITLE
Fix: timeOffset - Once enabled, Forever Enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -1801,7 +1801,7 @@ class HLSVod {
       }
     }
     const lastSeg = this.segments[sourceBw][this.segments[sourceBw].length - 1];
-    if (lastSeg && lastSeg.timelinePosition) {
+    if (this.timeOffset !== null && lastSeg && lastSeg.timelinePosition) {
       this.timeOffset = lastSeg.timelinePosition + lastSeg.duration * 1000;
     }
     this.segments[destBw].push({


### PR DESCRIPTION
The option to add program date time or timeline positions on each segment cannot truly be disabled if the `previousVod` had it enabled. This is due to the fact that `this.timeOffset` gets set in `_copyFromPrevious` regardless of what its value was around initiation time. 

This PR intends to fix this by only allowing `this.timeOffset` to be settable if it was set in the initialization stage.