### PR TITLE
Fix: Stop Using Previous VOD to Set timeOffset

### DIFF
--- a/index.js
+++ b/index.js
@@ -1932,7 +1932,7 @@ class HLSVod {
     }
     const lastSeg = this.segments[sourceBw][this.segments[sourceBw].length - 1];
     if (this.timeOffset !== null && lastSeg && lastSeg.timelinePosition) {
-      this.timeOffset = lastSeg.timelinePosition + lastSeg.duration * 1000;
+      this.timeOffset += lastSeg.duration * 1000;
     }
     this.segments[destBw].push({
       discontinuity: true,

--- a/index.js
+++ b/index.js
@@ -1930,10 +1930,7 @@ class HLSVod {
         this.segments[destBw].push(q);
       }
     }
-    const lastSeg = this.segments[sourceBw][this.segments[sourceBw].length - 1];
-    if (this.timeOffset !== null && lastSeg && lastSeg.timelinePosition) {
-      this.timeOffset += lastSeg.duration * 1000;
-    }
+
     this.segments[destBw].push({
       discontinuity: true,
       daterange: this.rangeMetadata ? this.rangeMetadata : null,

--- a/spec/hlsvod_spec.js
+++ b/spec/hlsvod_spec.js
@@ -686,9 +686,10 @@ describe("HLSVod with timeline", () => {
 
 
   it("can handle vod after another vod", (done) => {
+    const VOD_LENGTH_MS = 2646000 + 6266;
     const now = Date.now();
     mockVod = new HLSVod("http://mock.com/mock.m3u8", [], now);
-    mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", [], now + 1);
+    mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", [], now + VOD_LENGTH_MS);
     mockVod
       .load(mockMasterManifest, mockMediaManifest)
       .then(() => {
@@ -696,8 +697,8 @@ describe("HLSVod with timeline", () => {
       })
       .then(() => {
         const seqSegments = mockVod2.getLiveMediaSequenceSegments(0);
-        expect(seqSegments["2497000"][4].timelinePosition).toEqual(now + 2646 * 1000);
-        expect(seqSegments["2497000"][6].timelinePosition).toEqual(now + 2646 * 1000 + 6266);
+        expect(seqSegments["2497000"][4].timelinePosition).toEqual(now + VOD_LENGTH_MS - 6266);
+        expect(seqSegments["2497000"][6].timelinePosition).toEqual(now + VOD_LENGTH_MS);
         done();
       });
   });
@@ -755,8 +756,9 @@ describe("HLSVod with timeline", () => {
       },
     ];
     const now = Date.now();
+    const VOD_LENGTH_MS = 2646000 + 6266;
     mockVod = new HLSVod("http://mock.com/mock.m3u8", [], now);
-    mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", splices, now + 1);
+    mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", splices, now + VOD_LENGTH_MS);
     mockVod
       .load(mockMasterManifest, mockMediaManifest)
       .then(() => {
@@ -764,8 +766,8 @@ describe("HLSVod with timeline", () => {
       })
       .then(() => {
         const seqSegments = mockVod2.getLiveMediaSequenceSegments(0);
-        expect(seqSegments["2497000"][4].timelinePosition).toEqual(now + 2646 * 1000);
-        expect(seqSegments["2497000"][6].timelinePosition).toEqual(now + 2646 * 1000 + 6266);
+        expect(seqSegments["2497000"][4].timelinePosition).toEqual(now + VOD_LENGTH_MS - 6266);
+        expect(seqSegments["2497000"][6].timelinePosition).toEqual(now + VOD_LENGTH_MS);
         done();
       });
   });


### PR DESCRIPTION
PR will change the behavior of handling ProgramDateTime when loading one vod after another. 

The previous behavior was to ignore the set `this.timeOffset` timestamp and, instead, have it timeOffset rather be the timestamp of the final segment in the previous vod. This might not always yield in real-time timestamps as it assumes that the time of loading matches the time on the timestamp on that final segment. This is not always the case and even when it does not align with the true real-time, and there is no way to adjust the PDT in order to sync up later.

By using this updated behavior, the timeOffset will no longer be influenced by the previous vod. It only uses the value it gets from the initialization, which could help syncing the PDT with real-time, assuming that the given timeOffset in the constructor is a more dependable one. 