### PR TITLE
fix: hls-interstitial start-date not placed correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -2824,9 +2824,10 @@ class HLSVod {
 
                 if (playlistItemWithInterstitialsMetadata(playlistItem)) {
                   const newDateRange = playlistItem.attributes.attributes["daterange"];
-                  const newStartDate = new Date(newDateRange["START-DATE"]);
-                  const tempTimeOffset = new Date(this.timeOffset);
-                  const newStartDateString = new Date(newStartDate.getTime() + tempTimeOffset.getTime()).toISOString();
+                  const vodsInputTimestamp = new Date(this.timeOffset);
+                  const extraDurationSec = i == 0 && q.duration ? 0 : q.duration;
+                  const startTimeOffsetMs = (position + extraDurationSec) * 1000;
+                  const newStartDateString = new Date(vodsInputTimestamp.getTime() + startTimeOffsetMs).toISOString();
                   newDateRange["START-DATE"] = newStartDateString;
                   q["daterange"] = newDateRange;
                 }

--- a/spec/hlsvod_spec.js
+++ b/spec/hlsvod_spec.js
@@ -3809,5 +3809,35 @@ describe("HLSVod delta time and positions", () => {
         });
       });
     });
+
+    it("with Program date time enabled and VODs have HLS Interstitial Tag", (done) => {
+      mockVod = new HLSVod("http://mock.com/mock.m3u8", null, Date.now(), 0, null, {
+        sequenceAlwaysContainNewSegments: 0,
+        forcedDemuxMode: true,
+      });
+      mockVod2 = new HLSVod("http://mock.com/mock2.m3u8", null, Date.now() + 90000, 0, null, {
+        sequenceAlwaysContainNewSegments: 0,
+        forcedDemuxMode: true,
+      });
+      mockVod.load(mock_vod_3.master, mock_vod_3.media, mock_vod_3.audio).then(() => {
+        mockVod2.loadAfter(mockVod, mock_vod_3.master, mock_vod_3.media, mock_vod_3.audio).then(() => {
+          let m3u8 = mockVod2.getLiveMediaAudioSequences(0, "audio-aacl-256", "sv", 4);
+          let lines = m3u8.split("\n");
+          expect(
+            lines[16].includes('#EXT-X-DATERANGE:ID="ad1",CLASS="com.apple.hls.interstitial",START-DATE') &&
+              lines[16].includes(
+                ',DURATION="15.0",X-ASSET-URI="http://example.com/ad1.m3u8",X-RESUME-OFFSET="0",X-RESTRICT="SKIP,JUMP",X-COM-EXAMPLE-BEACON="123"'
+              )
+          ).toBe(true);
+          expect(
+            lines[17].includes('#EXT-X-DATERANGE:ID="ad1",CLASS="com.apple.hls.interstitial",START-DATE') &&
+              lines[16].includes(
+                ',DURATION="15.0",X-ASSET-URI="http://example.com/ad1.m3u8",X-RESUME-OFFSET="0",X-RESTRICT="SKIP,JUMP",X-COM-EXAMPLE-BEACON="123"'
+              )
+          ).toBe(false);
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR involves the support for hls interstitials, improving the accuracy of calculating the START-DATE based on the program date and time of segments preceding it.  

Especially for the case when the next vod is loaded in and has an interstitial positioned at the start of the vod, as before it would be off a few seconds from what was expected
