### PR TITLE
fix: correct CUE tag placement in CMAF HLS manifests

### DIFF
--- a/spec/hlsvod_cmaf_spec.js
+++ b/spec/hlsvod_cmaf_spec.js
@@ -238,7 +238,7 @@ describe("HLSVod CMAF after another CMAF VOD, for demuxed tracks with unmatching
     });
   });
 
-  fit("and with 'sequenceAlwaysContainNewSegments=true' will have correct positions", (done) => {
+  it("and with 'sequenceAlwaysContainNewSegments=true' will have correct positions", (done) => {
     process.env.SEQUENCE_DURATION = 59;
     mockVod = new HLSVod("http://mock.com/mock.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1, forcedDemuxMode: 1 });
     mockVod2 = new HLSVod("http://mock.com/mock_2.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1, forcedDemuxMode: 1 });
@@ -332,7 +332,7 @@ describe("HLSVod CMAF after another CMAF VOD, for demuxed tracks with unmatching
 
         //console.log(mapPositions(playheadPositionsV, playheadPositionsA), m3u8_audio_on_ad_end, m3u8_video_on_ad_end);
         expect(mapPositions(playheadPositionsV, playheadPositionsA)).toEqual(expectedPositionAndIndexMapping);
-        
+
         expect(lines_1[34]).toBe("http://mock.com/vod1-audio=256000-77.m4s");
         expect(lines_1[36]).toBe("http://mock.com/vod1-audio=256000-78.m4s");
         expect(lines_2[34]).toBe("http://mock.com/vod1-video=300000-76.m4s");

--- a/spec/hlsvod_cmaf_spec.js
+++ b/spec/hlsvod_cmaf_spec.js
@@ -147,27 +147,30 @@ describe("HLSVod CMAF after another CMAF VOD", () => {
       .then(() => {
         let m3u8 = mockVod2.getLiveMediaSequences(0, "2500000", 10);
         let lines = m3u8.split("\n");
+
         expect(lines[6]).toEqual(`#EXT-X-MAP:URI="http://mock.com/test-video=2500000.m4s"`);
         expect(lines[8]).toEqual(`http://mock.com/test-video=2500000-51.m4s`);
-        expect(lines[26]).toEqual(
+        expect(lines[27]).toEqual(
           `#EXT-X-MAP:URI="https://ovpuspvod.a2d-stage.tv/trailers/63ef9c36e3ffa90028603374/output.ism/hls/output-video=1500000.m4s"`
         );
-        expect(lines[27]).toEqual(`#EXT-X-CUE-OUT:DURATION=20`);
+
+        expect(lines[26]).toEqual(`#EXT-X-CUE-OUT:DURATION=20`);
         expect(lines[29]).toEqual(`https://ovpuspvod.a2d-stage.tv/trailers/63ef9c36e3ffa90028603374/output.ism/hls/output-video=1500000-1.m4s`);
-        expect(lines[41]).toEqual(`#EXT-X-MAP:URI="http://mock.com/test-video=2500000.m4s"`);
-        expect(lines[42]).toEqual(`#EXT-X-CUE-IN`);
+        expect(lines[42]).toEqual(`#EXT-X-MAP:URI="http://mock.com/test-video=2500000.m4s"`);
+        expect(lines[41]).toEqual(`#EXT-X-CUE-IN`);
         expect(lines[44]).toEqual(`http://mock.com/test-video=2500000-1.m4s`);
         m3u8 = mockVod2.getLiveMediaAudioSequences(0, "audio-aacl-256", "sv", 10);
         lines = m3u8.split("\n");
+
         expect(lines[6]).toEqual(`#EXT-X-MAP:URI="http://mock.com/test-audio=256000.m4s"`);
         expect(lines[8]).toEqual(`http://mock.com/test-audio=256000-73.m4s`);
-        expect(lines[48]).toEqual(
+        expect(lines[49]).toEqual(
           `#EXT-X-MAP:URI="https://ovpuspvod.a2d-stage.tv/trailers/63ef9c36e3ffa90028603374/output.ism/hls/output-audio=128000.m4s"`
         );
-        expect(lines[49]).toEqual(`#EXT-X-CUE-OUT:DURATION=20.032`);
+        expect(lines[48]).toEqual(`#EXT-X-CUE-OUT:DURATION=20.032`);
         expect(lines[51]).toEqual(`https://ovpuspvod.a2d-stage.tv/trailers/63ef9c36e3ffa90028603374/output.ism/hls/output-audio=128000-1.m4s`);
-        expect(lines[63]).toEqual(`#EXT-X-MAP:URI="http://mock.com/test-audio=256000.m4s"`);
-        expect(lines[64]).toEqual(`#EXT-X-CUE-IN`);
+        expect(lines[64]).toEqual(`#EXT-X-MAP:URI="http://mock.com/test-audio=256000.m4s"`);
+        expect(lines[63]).toEqual(`#EXT-X-CUE-IN`);
         expect(lines[66]).toEqual(`http://mock.com/test-audio=256000-1.m4s`);
         done();
       });
@@ -250,7 +253,7 @@ describe("HLSVod CMAF after another CMAF VOD, for demuxed tracks with unmatching
         let m3u8_video_before_ad_end = mockVod2.getLiveMediaSequences(0, "1120000", 23);
         let m3u8_audio_on_ad_end = mockVod2.getLiveMediaAudioSequences(0, "aac", "en", 24);
         let m3u8_video_on_ad_end = mockVod2.getLiveMediaSequences(0, "1120000", 24);
-
+        
         let lines_1 = m3u8_audio_before_ad_start.split("\n");
         let lines_2 = m3u8_video_before_ad_start.split("\n");
         let lines_3 = m3u8_audio_on_ad_start.split("\n");
@@ -332,12 +335,12 @@ describe("HLSVod CMAF after another CMAF VOD, for demuxed tracks with unmatching
 
         expect(lines_1[36]).toBe("http://mock.com/vod1-audio=256000-78.m4s");
         expect(lines_2[36]).toBe("http://mock.com/vod1-video=300000-77.m4s");
-        expect(lines_3[37]).toBe("#EXT-X-CUE-OUT:DURATION=83");
-        expect(lines_4[37]).toBe("#EXT-X-CUE-OUT:DURATION=83");
+        expect(lines_3[36]).toBe("#EXT-X-CUE-OUT:DURATION=83");
+        expect(lines_4[36]).toBe("#EXT-X-CUE-OUT:DURATION=83");
         expect(lines_5[44]).toBe("http://mock.com/bumper1-audio=128000-1.m4s");
-        expect(lines_6[44]).toBe("http://mock.com/bumper1-video=300000-1.m4s");
-        expect(lines_7[43]).toBe("#EXT-X-CUE-IN");
-        expect(lines_8[45]).toBe("#EXT-X-CUE-IN");
+        expect(lines_6[42]).toBe("http://mock.com/bumper1-video=300000-1.m4s");
+        expect(lines_7[42]).toBe("#EXT-X-CUE-IN");
+        expect(lines_8[42]).toBe("#EXT-X-CUE-IN");
         process.env.SEQUENCE_DURATION = 60;
         done();
       });

--- a/spec/hlsvod_cmaf_spec.js
+++ b/spec/hlsvod_cmaf_spec.js
@@ -238,7 +238,7 @@ describe("HLSVod CMAF after another CMAF VOD, for demuxed tracks with unmatching
     });
   });
 
-  it("and with 'sequenceAlwaysContainNewSegments=true' will have correct positions", (done) => {
+  fit("and with 'sequenceAlwaysContainNewSegments=true' will have correct positions", (done) => {
     process.env.SEQUENCE_DURATION = 59;
     mockVod = new HLSVod("http://mock.com/mock.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1, forcedDemuxMode: 1 });
     mockVod2 = new HLSVod("http://mock.com/mock_2.m3u8", null, 0, 0, null, { sequenceAlwaysContainNewSegments: 1, forcedDemuxMode: 1 });
@@ -332,10 +332,14 @@ describe("HLSVod CMAF after another CMAF VOD, for demuxed tracks with unmatching
 
         //console.log(mapPositions(playheadPositionsV, playheadPositionsA), m3u8_audio_on_ad_end, m3u8_video_on_ad_end);
         expect(mapPositions(playheadPositionsV, playheadPositionsA)).toEqual(expectedPositionAndIndexMapping);
-
+        
+        expect(lines_1[34]).toBe("http://mock.com/vod1-audio=256000-77.m4s");
         expect(lines_1[36]).toBe("http://mock.com/vod1-audio=256000-78.m4s");
+        expect(lines_2[34]).toBe("http://mock.com/vod1-video=300000-76.m4s");
         expect(lines_2[36]).toBe("http://mock.com/vod1-video=300000-77.m4s");
+        expect(lines_3[35]).toBe("#EXT-X-DISCONTINUITY");
         expect(lines_3[36]).toBe("#EXT-X-CUE-OUT:DURATION=83");
+        expect(lines_4[35]).toBe("#EXT-X-DISCONTINUITY");
         expect(lines_4[36]).toBe("#EXT-X-CUE-OUT:DURATION=83");
         expect(lines_5[44]).toBe("http://mock.com/bumper1-audio=128000-1.m4s");
         expect(lines_6[42]).toBe("http://mock.com/bumper1-video=300000-1.m4s");

--- a/testvectors/hls_cmaf_demux_2_pre/test-audio=256000.m3u8
+++ b/testvectors/hls_cmaf_demux_2_pre/test-audio=256000.m3u8
@@ -6,13 +6,13 @@
 #EXT-X-INDEPENDENT-SEGMENTS
 #EXT-X-TARGETDURATION:4
 #USP-X-TIMESTAMP-MAP:MPEGTS=900000,LOCAL=1970-01-01T00:00:00Z
-#EXT-X-MAP:URI="bumper1-audio=128000.m4s"
 #EXT-X-DISCONTINUITY
 #EXT-X-CUE-OUT:DURATION=83
+#EXT-X-MAP:URI="bumper1-audio=128000.m4s"
 #EXTINF:3.0293, no desc
 bumper1-audio=128000-1.m4s
-#EXT-X-MAP:URI="trailers/6410780885837c53d76220fa/seg-audio=128000.m4s"
 #EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="trailers/6410780885837c53d76220fa/seg-audio=128000.m4s"
 #EXTINF:3.8400, no desc
 trailers/6410780885837c53d76220fa/seg-audio=128000-1.m4s
 #EXTINF:3.8400, no desc
@@ -25,8 +25,8 @@ trailers/6410780885837c53d76220fa/seg-audio=128000-4.m4s
 trailers/6410780885837c53d76220fa/seg-audio=128000-5.m4s
 #EXTINF:0.8320, no desc
 trailers/6410780885837c53d76220fa/seg-audio=128000-6.m4s
-#EXT-X-MAP:URI="trailers/64258163d9bd4e002a287286/seg-audio=128000.m4s"
 #EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="trailers/64258163d9bd4e002a287286/seg-audio=128000.m4s"
 #EXTINF:3.8400, no desc
 trailers/64258163d9bd4e002a287286/seg-audio=128000-1.m4s
 #EXTINF:3.8400, no desc
@@ -43,14 +43,14 @@ trailers/64258163d9bd4e002a287286/seg-audio=128000-6.m4s
 trailers/64258163d9bd4e002a287286/seg-audio=128000-7.m4s
 #EXTINF:3.1573, no desc
 trailers/64258163d9bd4e002a287286/seg-audio=128000-8.m4s
-#EXT-X-MAP:URI="trailers/640f15469b636e51dcca74ba/seg-audio=128000.m4s"
 #EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="trailers/640f15469b636e51dcca74ba/seg-audio=128000.m4s"
 #EXTINF:3.8400, no desc
 trailers/640f15469b636e51dcca74ba/seg-audio=128000-1.m4s
 #EXTINF:3.2000, no desc
 trailers/640f15469b636e51dcca74ba/seg-audio=128000-2.m4s
-#EXT-X-MAP:URI="trailers/6409d2ff3d431f3269303b33/seg-audio=128000.m4s"
 #EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="trailers/6409d2ff3d431f3269303b33/seg-audio=128000.m4s"
 #EXTINF:3.8400, no desc
 trailers/6409d2ff3d431f3269303b33/seg-audio=128000-1.m4s
 #EXTINF:3.8400, no desc
@@ -63,13 +63,13 @@ trailers/6409d2ff3d431f3269303b33/seg-audio=128000-4.m4s
 trailers/6409d2ff3d431f3269303b33/seg-audio=128000-5.m4s
 #EXTINF:0.8320, no desc
 trailers/6409d2ff3d431f3269303b33/seg-audio=128000-6.m4s
-#EXT-X-MAP:URI="bumper1-audio=128000.m4s"
 #EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="bumper1-audio=128000.m4s"
 #EXTINF:3.0293, no desc
 bumper1-audio=128000-1.m4s
-#EXT-X-MAP:URI="vod2-audio=256000.m4s"
 #EXT-X-DISCONTINUITY
 #EXT-X-CUE-IN
+#EXT-X-MAP:URI="vod2-audio=256000.m4s"
 #EXTINF:3.8400, no desc
 vod2-audio=256000-1.m4s
 #EXTINF:3.8400, no desc

--- a/testvectors/hls_cmaf_demux_2_pre/test-video=2500000.m3u8
+++ b/testvectors/hls_cmaf_demux_2_pre/test-video=2500000.m3u8
@@ -6,13 +6,13 @@
 #EXT-X-INDEPENDENT-SEGMENTS
 #EXT-X-TARGETDURATION:6
 #USP-X-TIMESTAMP-MAP:MPEGTS=900000,LOCAL=1970-01-01T00:00:00Z
-#EXT-X-MAP:URI="bumper1-video=300000.m4s"
 #EXT-X-DISCONTINUITY
 #EXT-X-CUE-OUT:DURATION=83
+#EXT-X-MAP:URI="bumper1-video=300000.m4s"
 #EXTINF:3.0000, no desc
 bumper1-video=300000-1.m4s
-#EXT-X-MAP:URI="trailers/6410780885837c53d76220fa/seg-video=300000.m4s"
 #EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="trailers/6410780885837c53d76220fa/seg-video=300000.m4s"
 #EXTINF:3.8400, no desc
 trailers/6410780885837c53d76220fa/seg-video=300000-1.m4s
 #EXTINF:3.8400, no desc
@@ -25,8 +25,8 @@ trailers/6410780885837c53d76220fa/seg-video=300000-4.m4s
 trailers/6410780885837c53d76220fa/seg-video=300000-5.m4s
 #EXTINF:0.8000, no desc
 trailers/6410780885837c53d76220fa/seg-video=300000-6.m4s
-#EXT-X-MAP:URI="trailers/64258163d9bd4e002a287286/seg-video=300000.m4s"
 #EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="trailers/64258163d9bd4e002a287286/seg-video=300000.m4s"
 #EXTINF:3.8400, no desc
 trailers/64258163d9bd4e002a287286/seg-video=300000-1.m4s
 #EXTINF:3.8400, no desc
@@ -43,14 +43,14 @@ trailers/64258163d9bd4e002a287286/seg-video=300000-6.m4s
 trailers/64258163d9bd4e002a287286/seg-video=300000-7.m4s
 #EXTINF:3.1200, no desc
 trailers/64258163d9bd4e002a287286/seg-video=300000-8.m4s
-#EXT-X-MAP:URI="trailers/640f15469b636e51dcca74ba/seg-video=300000.m4s"
 #EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="trailers/640f15469b636e51dcca74ba/seg-video=300000.m4s"
 #EXTINF:3.8400, no desc
 trailers/640f15469b636e51dcca74ba/seg-video=300000-1.m4s
 #EXTINF:3.1600, no desc
 trailers/640f15469b636e51dcca74ba/seg-video=300000-2.m4s
+#EXT-X-MAP:URI="bumper1-video=300000.m4s"
 #EXT-X-MAP:URI="trailers/6409d2ff3d431f3269303b33/seg-video=300000.m4s"
-#EXT-X-DISCONTINUITY
 #EXTINF:3.8400, no desc
 trailers/6409d2ff3d431f3269303b33/seg-video=300000-1.m4s
 #EXTINF:3.8400, no desc
@@ -63,13 +63,13 @@ trailers/6409d2ff3d431f3269303b33/seg-video=300000-4.m4s
 trailers/6409d2ff3d431f3269303b33/seg-video=300000-5.m4s
 #EXTINF:0.8000, no desc
 trailers/6409d2ff3d431f3269303b33/seg-video=300000-6.m4s
-#EXT-X-MAP:URI="bumper1-video=300000.m4s"
 #EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="bumper1-video=300000.m4s"
 #EXTINF:3.0000, no desc
 bumper1-video=300000-1.m4s
-#EXT-X-MAP:URI="vod2-video=300000.m4s"
 #EXT-X-DISCONTINUITY
 #EXT-X-CUE-IN
+#EXT-X-MAP:URI="vod2-video=300000.m4s"
 #EXTINF:6.0000, no desc
 vod2-video=300000-1.m4s
 #EXTINF:3.0000, no desc


### PR DESCRIPTION


## Problem
When working with HLS CMAF, CUE tags are incorrectly placed after the MAP tag in the generated m3u8 file. According to HLS standards, the #EXT-X-MAP tag should appear immediately before the #EXTINF segment, with CUE tags preceding the MAP tag. Note: How it worked before did not affect playback in the end, but it was inconsistent m3u8 standards.

Additionally, the current implementation sometimes generates duplicate CUE tags in the manifest.

## Solution
- Reordered tag placement to ensure CUE tags appear before MAP tags
- Fixed logic to prevent duplicate CUE tags from being generated
- Added test cases to verify correct tag ordering

This change maintains backward compatibility and doesn't affect playback functionality, but ensures compliance with HLS manifest formatting standards.

## Before/After Example
![image](https://github.com/user-attachments/assets/d5a752a3-ba91-42e9-9548-dd4b4bb93fbf)
![image](https://github.com/user-attachments/assets/ff14a30a-881b-4d22-a0a9-fba198abe6c3)

